### PR TITLE
Modifications to get it to work on Ubuntu Server 20.04 on 64 bit ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM alpine 
-
+FROM alpine:3.9
 STOPSIGNAL 9
-  
 RUN apk --update --no-cache add --virtual build-dependencies build-base && \
     cd /tmp && \
     wget https://github.com/joan2937/pigpio/archive/master.zip && \
     unzip -qq master.zip && \
     cd pigpio-master && \
+    sed -i 's/|PROT_EXEC,/,/g' pigpio.c && \
     make && \
     sed -i 's/ldconfig/ldconfig \/usr\/local/g' Makefile && \
     make install && \
@@ -15,5 +14,6 @@ RUN apk --update --no-cache add --virtual build-dependencies build-base && \
     apk --no-cache add tini
 
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod u+x /entrypoint.sh
 
 ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,4 @@ echo "Starting PigPiod..."
 # gpiod sometimes leaves pid files around, just clean them
 rm -f /var/run/pigpio.pid 
 
-exec /usr/local/bin/pigpiod -g -a 1 $@
+exec /usr/local/bin/pigpiod -g $@


### PR DESCRIPTION
Modifications to get it to work on 64 bit CPU, where PROT_EXEC had to be removed. There is a PR for this at https://github.com/joan2937/pigpio/pull/342.

Removed -a 1 flags from pigpiod since it gives errors on Ubuntu Server 20.04 on 64 bit ARM.